### PR TITLE
Replaces uTP library with async-std-utp

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ authors = [
 
 [features]
 default = ["transport_utp"]
-transport_utp = ["libutp-rs"]
+transport_utp = ["async-std-utp"]
 
 [dependencies]
 async-std = { version = "1.9.0", features = ["unstable"] }
@@ -30,7 +30,7 @@ hex = "0.4.3"
 pretty-hash = "0.4.1"
 hyperswarm-dht = { git = "https://github.com/Frando/hyperswarm-dht.git", branch = "hyperspace" }
 colmeia-hyperswarm-mdns = { git = "https://github.com/bltavares/colmeia.git", rev = "e92ab71981356197a21592b7ce6854e209582985" }
-libutp-rs = { git = "https://github.com/Frando/libutp-rs.git", branch = "feat/clone", optional = true }
+async-std-utp = { version = "0.1.1", optional = true }
 
 [dev-dependencies]
 env_logger = "0.8.3"

--- a/src/transport/combined.rs
+++ b/src/transport/combined.rs
@@ -163,7 +163,7 @@ impl CombinedStream {
         match self {
             Self::Tcp(stream) => stream.peer_addr().unwrap(),
             #[cfg(feature = "transport_utp")]
-            Self::Utp(stream) => stream.peer_addr(),
+            Self::Utp(stream) => stream.peer_addr().unwrap(),
         }
     }
 


### PR DESCRIPTION
The current libutp-rs uses a C lib and has some use of libc that are only available on Unix platforms.
This did not compile on Windows, and this PR proposes a replacement lib on top of `utp` crate, which is written in Rust.

The crate has been integrated with async-std, so there is no need to compat with tokio