### PR TITLE
Updates: see list

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,9 @@ async-trait = "0.1.53"
 async-compat = "0.2.1"
 blake2-rfc = "0.2.18"
 
+[patch.crates-io]
+libutp-sys = { git = "https://github.com/cowlicks/libutp-sys.git", branch = "fix-build-failure", optional = true }
+
 [dev-dependencies]
 env_logger = "0.8.3"
 async-std = { version = "1.9.0", features = ["unstable", "attributes"] }

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@
 - [ ] resolve all git dependencies
   - [ ] [hyperswarm-dht](https://github.com/datrs/hyperswarm-dht/tree/hyperspace) uses "hyperspace" as the default branch
   - [ ] [colmeia-hyperswarm-mdns](https://github.com/bltavares/colmeia) currently using master
-  - [ ] [libutp-rs](https://github.com/Frando/libutp-rs/tree/feat/clone2). There is a crate from original author. but we use the branch linked. [crate link](https://crates.io/crates/libutp-rs)
+  - [ ] [libutp-rs](https://github.com/Frando/libutp-rs/tree/feat/clone2). There is a crate from original author. but we use the branch linked. [crate link](https://crates.io/crates/libutp-rs). `libutp-rs` depends on `libutp-sys` but that crate fails to build. I made a PR to fix this [here](https://github.com/johsunds/libutp-sys/pull/1). But it has gone unnoticed. Options: fork and publish these, or, convert this project to a workspace and include them here with fixes.
 
 ## Installation
 ```sh

--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@
 
 *NOTE: This is still in early stages. See the roadmap below. Please feel free to open issues and send PRs :-)*
 
+## TODO
+
+- [ ] switch to tokio from async-std
+- [ ] resolve all git dependencies
+  - [ ] [hyperswarm-dht](https://github.com/datrs/hyperswarm-dht/tree/hyperspace) uses "hyperspace" as the default branch
+  - [ ] [colmeia-hyperswarm-mdns](https://github.com/bltavares/colmeia) currently using master
+  - [ ] [libutp-rs](https://github.com/Frando/libutp-rs/tree/feat/clone2). There is a crate from original author. but we use the branch linked. [crate link](https://crates.io/crates/libutp-rs)
+
 ## Installation
 ```sh
 $ cargo add hyperswarm --git https://github.com/datrs/hyperswarm-rs.git


### PR DESCRIPTION
## TODO

- [ ] switch to tokio from async-std
- [ ] resolve all git dependencies to real crates. So we can publish this as a crate
  - [ ] [hyperswarm-dht](https://github.com/datrs/hyperswarm-dht/tree/hyperspace) uses "hyperspace" as the default branch
  - [ ] [colmeia-hyperswarm-mdns](https://github.com/bltavares/colmeia) currently using master
  - [ ] [libutp-rs](https://github.com/Frando/libutp-rs/tree/feat/clone2). There is a crate from original author. but we use the branch linked. [crate link](https://crates.io/crates/libutp-rs). `libutp-rs` depends on `libutp-sys` but that crate fails to build. I made a PR to fix this [here](https://github.com/johsunds/libutp-sys/pull/1). But it has gone unnoticed. Options:
      * fork and publish these
      * convert this project to a workspace and include them here with fixes.
      * use a different library like in #3 